### PR TITLE
Change oauth client's site after successful login

### DIFF
--- a/lib/omniauth/strategies/square.rb
+++ b/lib/omniauth/strategies/square.rb
@@ -6,6 +6,7 @@ module OmniAuth
 
       option :client_options, {
         :site          => 'https://squareup.com/',
+        :connect_site  => 'https://connect.squareup.com',
         :authorize_url => '/oauth2/authorize',
         :token_url     => '/oauth2/token'
       }
@@ -26,7 +27,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://connect.squareup.com/v1/me').parsed
+        @raw_info ||= access_token.get('/v1/me').parsed
       end
 
       protected
@@ -37,7 +38,9 @@ module OmniAuth
         parsed_response['expires_at'] = Time.parse(parsed_response['expires_at']).to_i
         parsed_response.merge!(deep_symbolize(options.auth_token_params))
 
-        ::OAuth2::AccessToken.from_hash(client, parsed_response)
+        connect_client = client.dup
+        connect_client.site = options.client_options.connect_site
+        ::OAuth2::AccessToken.from_hash(connect_client, parsed_response)
       end
 
       private

--- a/spec/omniauth/strategies/square_spec.rb
+++ b/spec/omniauth/strategies/square_spec.rb
@@ -131,11 +131,22 @@ describe OmniAuth::Strategies::Square do
   end
 
   describe '#build_access_token' do
+    let(:token_hash) do
+      {'expires_at' => Time.now.iso8601, 'access_token' => '1111111'}
+    end
+
+    before do
+      subject.stub(:fetch_access_token).and_return(token_hash.dup)
+      @token = subject.send :build_access_token
+    end
+
     it 'converts iso8601 expires_at to an integer' do
-      now = Time.now
-      subject.stub(:fetch_access_token).and_return({'expires_at' => now.iso8601})
-      token = subject.send(:build_access_token)
-      expect(token.expires_at).to eq(now.to_i)
+      expires = Time.parse(token_hash['expires_at']).to_i
+      expect(@token.expires_at).to eq(expires)
+    end
+
+    it 'changes the clients site' do
+      expect(@token.client.site).to eq('https://connect.squareup.com')
     end
   end
 


### PR DESCRIPTION
Square uses `squareup.com` for authentication, but uses `connect.squareup.com` for their APIs. This PR changes the client's site once authentication has been performed. Otherwise, requests performed with the access token (ex. `access_token.get('/v1/me')`) are sent to squareup.com leaving you with a 404.

Making `:connect_site` a client option allows user to override the URL for staging sites in their omniauth config.
