### PR TITLE
allow omniauth-oauth2 before 2.0.0

### DIFF
--- a/lib/omniauth/strategies/square.rb
+++ b/lib/omniauth/strategies/square.rb
@@ -74,6 +74,11 @@ module OmniAuth
         opts
       end
 
+      # for compatibility with omniauth 1.4.0
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def prune!(hash)
         hash.delete_if do |_, value|
           prune!(value) if value.is_a?(Hash)

--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 1.3.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 2.0.0'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Bump the allowable range for omniauth-auth2, up to `< 2.0.0`

In particular, allowing omniauth-oauth2 >= `1.6.0` is necessary for compatibility with [omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2/blob/master/omniauth-google-oauth2.gemspec#L26).